### PR TITLE
DP-25: travis 2.1 dotnet update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   include:
   - language: csharp
     mono: none
-    dotnet: 2.0
+    dotnet: 2.1
     before_script:
     - cd TestTemplate/cSharp/ConsoleWithTest/
     script:


### PR DESCRIPTION
### [DP-25: Updating travis is dotnet 2.1](https://jira.aipiggybot.io/browse/DP-25)

[Download for mac](https://www.microsoft.com/net/download/macos)